### PR TITLE
Add scope to reports

### DIFF
--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -80,7 +80,7 @@ powerdns:
     - PDNS_DB=powerdns
 
 zimbra:
-  image: zextras/zimbra8:8.6.0p7
+  image: jorgedlcruz/zimbra
   hostname: zimbra
   domainname: jenova.com
   mem_limit: 2G

--- a/src/jenova/app.py
+++ b/src/jenova/app.py
@@ -6,8 +6,8 @@ from flask import (
 from werkzeug.exceptions import default_exceptions
 from werkzeug.exceptions import HTTPException
 from werkzeug.contrib.fixers import ProxyFix
-from flask.ext.cors import CORS
-from flask.ext import restful
+from flask_cors import CORS
+import flask_restful as restful
 from traceback import format_exc
 
 from jenova.components import db, create_app, Config, CallLogger
@@ -200,7 +200,7 @@ try:
   if is_dev():
     with app.app_context():
       db.create_all()
-      from jenova.models import User, UserSchema
+      from jenova.models import User, UserSchema, Scope, Permissions
       from jenova.components import Security
       from datetime import datetime
       import jwt
@@ -215,18 +215,16 @@ try:
           global_admin = True
         )
 
-        '''
-        for scope in DEFAULT_SCOPES:
-          scope = Scope(name = scope_name)
-          scope.permissions = Permissions(
-            read = reqdata.get('read') or False,
-            write = reqdata.get('write') or False,
-            delete = reqdata.get('delete') or False,
-            edit = reqdata.get('edit') or False
-          )
-          db.session.add(scope)
-          db.session.commit()
-        '''
+        # for scope_name in DEFAULT_SCOPES:
+        #   scope = Scope(name = scope_name)
+        #   scope.permissions = Permissions(
+        #     read = True,
+        #     write = True,
+        #     delete = True,
+        #     edit = True
+        #   )
+        #   db.session.add(scope)
+        #   db.session.commit()
 
 
         #plain_secretkey, hashed_secretkey = os.environ.get('SECRETKEY'), os.environ.get('HASHED_SECRETKEY')
@@ -252,6 +250,8 @@ except Exception, ex:
 
 if __name__ == '__main__':
   try:
+    if is_dev():
+      app.run(host='0.0.0.0', port=8443, debug=True, threaded=True)
     context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
     context.load_cert_chain(os.environ.get('JNV_SSL_CERT'), os.environ.get('JNV_SSL_KEY'))
     app.run(host='0.0.0.0', port=8443, debug=True, ssl_context=context, threaded=True)

--- a/src/jenova/components/extensions.py
+++ b/src/jenova/components/extensions.py
@@ -1,3 +1,3 @@
-from flask.ext.sqlalchemy import SQLAlchemy
+from flask_sqlalchemy import SQLAlchemy
 
 db = SQLAlchemy()

--- a/src/jenova/components/mxhero.py
+++ b/src/jenova/components/mxhero.py
@@ -1,6 +1,6 @@
 import json, requests
 from .exceptions import mxheroError
-from flask.ext.restful import abort
+from flask_restful import abort
 
 
 class Mxhero(object):

--- a/src/jenova/components/powerdns.py
+++ b/src/jenova/components/powerdns.py
@@ -1,5 +1,5 @@
 import json, requests, re, ast
-from flask.ext.restful import abort
+from flask_restful import abort
 from .exceptions import DnsError
 from datetime import datetime, timedelta
 from .common import logger

--- a/src/jenova/resources/base.py
+++ b/src/jenova/resources/base.py
@@ -1,7 +1,7 @@
 import jwt, base64, json
 from collections import namedtuple
 from werkzeug.exceptions import InternalServerError
-from flask.ext.restful import reqparse, request, Resource, abort
+from flask_restful import reqparse, request, Resource, abort
 from functools import wraps
 from time import sleep
 
@@ -24,7 +24,9 @@ DEFAULT_SCOPES = [
   'service',
   'store',
   'users',
-  'zimbra'
+  'zimbra',
+  'client',
+  'permissions'
 ]
 PERMS = ['write', 'read', 'edit', 'delete']
 
@@ -34,7 +36,6 @@ def abort_if_obj_doesnt_exist(filter_by, target, model_object):
       target = int(target)
     except ValueError, e:
       raise
-      
   query = { filter_by : target }
   result = model_object.query.filter_by(**query).first()
   if not result:
@@ -101,8 +102,8 @@ class BaseResource(Resource):
     token = parts[1]
     try:
       payload = jwt.decode(
-        token, 
-        Security.get_jwt_skey(), 
+        token,
+        Security.get_jwt_skey(),
         algorithms = ['HS256']
       )
     except jwt.ExpiredSignature:
@@ -242,7 +243,7 @@ class TaskResource(BaseResource):
     except Exception:
       task_state = 'ERROR'
       task_executed = True
-    
+
     return {
       'response' : {
         'task_state' : task_state,

--- a/src/jenova/resources/cos.py
+++ b/src/jenova/resources/cos.py
@@ -1,5 +1,5 @@
 import ast
-from flask.ext.restful import abort, request
+from flask_restful import abort, request
 from jenova.resources.base import BaseResource, abort_if_obj_doesnt_exist
 from jenova.models import Cos, CosSchema, Features, Service, Domain
 from jenova.components import db

--- a/src/jenova/resources/distribution_list.py
+++ b/src/jenova/resources/distribution_list.py
@@ -1,4 +1,4 @@
-from flask.ext.restful import abort, request
+from flask_restful import abort, request
 import json
 
 from jenova.resources.base import BaseResource, abort_if_obj_doesnt_exist

--- a/src/jenova/resources/dns.py
+++ b/src/jenova/resources/dns.py
@@ -1,4 +1,4 @@
-from flask.ext.restful import abort, Resource, reqparse
+from flask_restful import abort, Resource, reqparse
 from datetime import datetime, timedelta
 import hmac, hashlib, time, uuid, re, json, gzip, ast
 

--- a/src/jenova/resources/domain.py
+++ b/src/jenova/resources/domain.py
@@ -3,7 +3,7 @@ General information about domains and services
 """
 
 from sqlalchemy import distinct
-from flask.ext.restful import abort, Resource, reqparse
+from flask_restful import abort, Resource, reqparse
 from flask import redirect, request
 from datetime import datetime
 from celery import chain

--- a/src/jenova/resources/external_accounts.py
+++ b/src/jenova/resources/external_accounts.py
@@ -1,4 +1,4 @@
-from flask.ext.restful import abort, request
+from flask_restful import abort, request
 import json, datetime
 
 from jenova.resources.base import BaseResource, abort_if_obj_doesnt_exist

--- a/src/jenova/resources/notices.py
+++ b/src/jenova/resources/notices.py
@@ -1,4 +1,4 @@
-from flask.ext.restful import abort
+from flask_restful import abort
 from datetime import datetime
 from time import sleep
 

--- a/src/jenova/resources/reseller.py
+++ b/src/jenova/resources/reseller.py
@@ -1,4 +1,4 @@
-from flask.ext.restful import abort, request
+from flask_restful import abort, request
 from datetime import datetime
 import uuid
 

--- a/src/jenova/resources/service.py
+++ b/src/jenova/resources/service.py
@@ -1,4 +1,4 @@
-from flask.ext.restful import abort
+from flask_restful import abort
 from datetime import datetime
 from time import sleep
 

--- a/src/jenova/resources/user.py
+++ b/src/jenova/resources/user.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 import uuid, jwt
 
-from flask.ext.restful import abort, Resource, reqparse, request
+from flask_restful import abort, Resource, reqparse, request
 from jenova.resources.base import BaseResource, abort_if_obj_doesnt_exist
 from jenova.components import Security, db
 from jenova.models import Client, User, Scope, ScopeSchema, Permissions, UserSchema, Reseller


### PR DESCRIPTION
- Add 'zimbra' scope to Reports endpoint
- Dev environment now run without ssl dependencies

For a user to be able to see reports the 'zimbra' scope must be set with the proper permissions (read/write/edit/delete).

Ref: #4 